### PR TITLE
Fix decalibration 

### DIFF
--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -148,6 +148,7 @@ static uint8_t head = 0;
 static uint8_t tail = 0;
 static uint8_t circular_counter = 0;
 static float circular_buffer_in_volts[ SAMPLES ];
+static float switch_positions_in_volts;
 
 static void adc_read_callback( void );
 static void define_default_values( void );
@@ -672,7 +673,6 @@ static THD_FUNCTION( speed_thread, arg )
 
     chRegSetThreadName( "speed_pid" );
 
-    static float switch_positions_in_volts;
     static systime_t overload_time_in_systicks = SYSTICK_ZERO_VALUE;
     static systime_t no_grind_time_in_systicks = SYSTICK_ZERO_VALUE;
     static uint8_t grind_attemp = ZERO_GRIND_ATTEMPS;

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -466,7 +466,7 @@ static void encoder_calibrate_offset( void )
 
     encoder_total_value_volts = knob_read_in_volts;
 
-    if( !is_momentary_position() && !is_in_maximum_detection )
+    if( ( switch_positions_in_volts < SWITCH_MOMENTARY_POSITION_IN_VOLTS ) && !is_in_maximum_detection )
     {
         encoder_min_value_in_volts = encoder_total_value_volts;
         offset_value.as_float = encoder_min_value_in_volts;

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -141,7 +141,6 @@ static bool is_stop_state = false;
 static bool is_motor_stalled_fault = false;
 static bool is_motor_grinding_enable = true;
 static bool is_in_maximum_detection = false;
-static bool is_maximum_done = false;
 static uint8_t is_calibration_done = 0;
 static uint8_t head = 0;
 static uint8_t tail = 0;

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -718,7 +718,7 @@ static THD_FUNCTION( speed_thread, arg )
                 is_stop_state = true;
             }
 
-            if( ( switch_positions_in_volts < SWITCH_MOMENTARY_POSITION_IN_VOLTS ) && is_calibration_done )
+            if( ( switch_positions_in_volts < SWITCH_MOMENTARY_POSITION_IN_VOLTS ) )
             {
                 if( safety_calibration )
                 {

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -661,6 +661,8 @@ static THD_FUNCTION( speed_thread, arg )
 
     chRegSetThreadName( "speed_pid" );
 
+    chThdSleepMilliseconds( 2000 );
+
     static systime_t overload_time_in_systicks = SYSTICK_ZERO_VALUE;
     static systime_t no_grind_time_in_systicks = SYSTICK_ZERO_VALUE;
     static uint8_t grind_attemp = ZERO_GRIND_ATTEMPS;

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -254,8 +254,6 @@ void hw_init_gpio( void )
 
     define_default_values();
 
-    encoder_calibrate_offset();
-
     chThdCreateStatic( speed_thread_wa, sizeof( speed_thread_wa ), NORMALPRIO, speed_thread, NULL );
 
     chThdCreateStatic( encoder_thread_wa, sizeof( encoder_thread_wa ), NORMALPRIO, encoder_thread, NULL );

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -143,7 +143,6 @@ static bool is_motor_grinding_enable = true;
 static bool is_in_maximum_detection = false;
 static bool is_maximum_done = false;
 static uint8_t is_calibration_done = 0;
-static uint8_t calibration_counter = 0;
 static uint8_t head = 0;
 static uint8_t tail = 0;
 static uint8_t circular_counter = 0;
@@ -473,12 +472,7 @@ static void encoder_calibrate_offset( void )
         calibration_check.as_i32 = is_calibration_done;
         conf_general_store_eeprom_var_hw( &calibration_check, EEPROM_ADDR_CALIBRATION_CHECK );
         safety_calibration = false;
-        calibration_counter++;
-
-        if( calibration_counter > 1 )
-        {
-            is_in_maximum_detection = true;
-        }
+        is_in_maximum_detection = true;
     }
 }
 
@@ -591,14 +585,11 @@ static void adc_get_maximum_value( void )
 {
     eeprom_var adc_maximum_value_in_volts;
 
-    if( ( calibration_counter > 1 ) && !is_maximum_done )
+    if( knob_read_in_volts > get_maximum_adc_value_in_volts )
     {
-        if( knob_read_in_volts > get_maximum_adc_value_in_volts )
-        {
-            get_maximum_adc_value_in_volts = knob_read_in_volts;
-            adc_maximum_value_in_volts.as_float = get_maximum_adc_value_in_volts;
-            conf_general_store_eeprom_var_hw( &adc_maximum_value_in_volts, EEPROM_ADDR_ADC_MAX_VALUE );
-        }
+        get_maximum_adc_value_in_volts = knob_read_in_volts;
+        adc_maximum_value_in_volts.as_float = get_maximum_adc_value_in_volts;
+        conf_general_store_eeprom_var_hw( &adc_maximum_value_in_volts, EEPROM_ADDR_ADC_MAX_VALUE );
     }
 }
 
@@ -654,7 +645,6 @@ static void terminal_print_info( int argc,
     commands_printf( "step: %f", ( double ) steps );
     commands_printf( "speed (eRPM): %f", ( double ) speed_erpm_setpoint );
     commands_printf( "speed (RPM): %f", ( double ) ( speed_erpm_setpoint / 4 ) );
-    commands_printf( "counter: %d", calibration_counter );
     commands_printf( "max adc: %f", ( double ) get_maximum_adc_value_in_volts );
 }
 
@@ -756,11 +746,7 @@ static THD_FUNCTION( speed_thread, arg )
                         set_erpm_ramp_response();
                         encoder_calibrate_offset();
                         encoder_cal_detection();
-
-                        if( calibration_counter > 1 )
-                        {
-                            store_minimum_value = true;
-                        }
+                        store_minimum_value = true;
                     }
 
                     adc_get_maximum_value();

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -472,7 +472,7 @@ static void encoder_calibrate_offset( void )
         is_calibration_done = 1;
         calibration_check.as_i32 = is_calibration_done;
         conf_general_store_eeprom_var_hw( &calibration_check, EEPROM_ADDR_CALIBRATION_CHECK );
-        safety_calibration = true;
+        safety_calibration = false;
         calibration_counter++;
 
         if( calibration_counter > 1 )
@@ -728,7 +728,7 @@ static THD_FUNCTION( speed_thread, arg )
 
             if( ( switch_positions_in_volts < SWITCH_MOMENTARY_POSITION_IN_VOLTS ) && is_calibration_done )
             {
-                if( !safety_calibration )
+                if( safety_calibration )
                 {
                     if( !is_erpm_done )
                     {
@@ -768,7 +768,7 @@ static THD_FUNCTION( speed_thread, arg )
             }
             else
             {
-                safety_calibration = false;
+                safety_calibration = true;
                 is_erpm_done = false;
                 is_encoder_done = false;
 


### PR DESCRIPTION
closes #8 

 The following changes have been implemented to address the decalibration issue.

- Reading of switch ADC values for the calibration process.
- Eliminate of the calibration process at startup and execute it when the thread that manages the switch is running.
- Addition of a delay in thread that read the switch status to obtain correct readings of the switch's ADC values.
- Change in the logic of the calibration process. ( momentary position)
- Removal of unused variables.

