### PR TITLE
Fix motor decalibration

### DIFF
--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -576,9 +576,6 @@ static void encoder_cal_detection( void )
 
     mcpwm_foc_encoder_detect( current, false, &offset, &ratio, &inverted );
 
-    // encoder_offset.as_float = offset;
-    // conf_general_store_eeprom_var_hw( &encoder_offset, EEPROM_ADDR_ENCODER_MOTOR_OFFSET );
-
     mcconf_previous->foc_encoder_offset = offset;
     mcconf->foc_encoder_offset = offset;
 

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -576,11 +576,14 @@ static void encoder_cal_detection( void )
 
     mcpwm_foc_encoder_detect( current, false, &offset, &ratio, &inverted );
 
-    encoder_offset.as_float = offset;
-    conf_general_store_eeprom_var_hw( &encoder_offset, EEPROM_ADDR_ENCODER_MOTOR_OFFSET );
+    // encoder_offset.as_float = offset;
+    // conf_general_store_eeprom_var_hw( &encoder_offset, EEPROM_ADDR_ENCODER_MOTOR_OFFSET );
 
     mcconf_previous->foc_encoder_offset = offset;
     mcconf->foc_encoder_offset = offset;
+
+    encoder_offset.as_float = offset;
+    conf_general_store_eeprom_var_hw( &encoder_offset, EEPROM_ADDR_ENCODER_MOTOR_OFFSET );
 
     mc_interface_set_configuration( mcconf );
     mc_interface_set_configuration( mcconf_previous );

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -41,6 +41,7 @@
 #define EEPROM_ADDR_MIN_CALIBRATED_VALUE      ( 8 )
 #define EEPROM_ADDR_STEPS_VALUE               ( 10 )
 #define EEPROM_ADDR_ADC_MAX_VALUE             ( 12 )
+#define EEPROM_ADDR_ENCODER_MOTOR_OFFSET      ( 16 )
 #define CURRENT_MOTOR_TIMEOUT_MS              ( 250 )
 #define GRIND_TIMEOUT_SEC                     ( 600 )
 #define CUTOFF_CURRENT_AMPS                   ( 3.0f )
@@ -473,6 +474,16 @@ static void define_default_values( void )
     get_maximum_adc_value_in_volts = adc_maximum_value_stored.as_float;
 }
 
+float read_motor_encoder_offset( void )
+{
+    eeprom_var motor_encoder_offset;
+    float motor_encoder_offset_value;
+
+    conf_general_read_eeprom_var_hw( &motor_encoder_offset, EEPROM_ADDR_ENCODER_MOTOR_OFFSET );
+    motor_encoder_offset_value = motor_encoder_offset.as_float;
+    return( motor_encoder_offset_value );
+}
+
 static void encoder_calibrate_offset( void )
 {
     eeprom_var offset_value;
@@ -546,6 +557,7 @@ static void set_pid_kd_constant( void )
 static void encoder_cal_detection( void )
 {
     mc_configuration * mcconf = mempools_alloc_mcconf();
+    eeprom_var encoder_offset;
 
     *mcconf = *mc_interface_get_configuration();
     mc_configuration * mcconf_previous = mempools_alloc_mcconf();
@@ -563,6 +575,9 @@ static void encoder_cal_detection( void )
     bool inverted = false;
 
     mcpwm_foc_encoder_detect( current, false, &offset, &ratio, &inverted );
+
+    encoder_offset.as_float = offset;
+    conf_general_store_eeprom_var_hw( &encoder_offset, EEPROM_ADDR_ENCODER_MOTOR_OFFSET );
 
     mcconf_previous->foc_encoder_offset = offset;
     mcconf->foc_encoder_offset = offset;

--- a/hwconf/Zerno/hw_zerno_drive_core.h
+++ b/hwconf/Zerno/hw_zerno_drive_core.h
@@ -267,17 +267,20 @@
 #define READ_HALL2()    palReadPad( HW_HALL_ENC_GPIO2, HW_HALL_ENC_PIN2 )
 #define READ_HALL3()    palReadPad( HW_HALL_ENC_GPIO3, HW_HALL_ENC_PIN3 )
 
-#define HW_DEAD_TIME_NSEC     250.0
+#define HW_DEAD_TIME_NSEC            250.0
 
 // Setting limits
-#define HW_LIM_CURRENT        -8.0, 8.0
-#define HW_LIM_CURRENT_IN     -6.0, 6.0
-#define HW_LIM_CURRENT_ABS    0.0, 13.0
-#define HW_LIM_VIN            100.0, 450.0
-#define HW_LIM_ERPM           -60e3, 60e3
-#define HW_LIM_DUTY_MIN       0.0, 0.1
-#define HW_LIM_DUTY_MAX       0.0, 0.99
-#define HW_LIM_TEMP_FET       -40.0, 110.0
+#define HW_LIM_CURRENT               -8.0, 8.0
+#define HW_LIM_CURRENT_IN            -6.0, 6.0
+#define HW_LIM_CURRENT_ABS           0.0, 13.0
+#define HW_LIM_VIN                   100.0, 450.0
+#define HW_LIM_ERPM                  -60e3, 60e3
+#define HW_LIM_DUTY_MIN              0.0, 0.1
+#define HW_LIM_DUTY_MAX              0.0, 0.99
+#define HW_LIM_TEMP_FET              -40.0, 110.0
+
+// a way to read the stored calibrated encoder offset value
+#define MCCONF_FOC_ENCODER_OFFSET    read_motor_encoder_offset()
 
 // Functions
 bool is_momentary_position( void );
@@ -286,6 +289,6 @@ bool is_hw_fault( void );
 float get_pfc_temp( void );
 float get_adc_filtered( void );
 float get_knob_read( void );
-
+float read_motor_encoder_offset( void );
 
 #endif /* HW_ZERNO_DRIVE_CORE_H_ */

--- a/hwconf/Zerno/mcconf_zerno_drive.h
+++ b/hwconf/Zerno/mcconf_zerno_drive.h
@@ -283,11 +283,6 @@
     #define MCCONF_FOC_ENCODER_INVERTED    0
 #endif
 
-// Encoder Offset
-#ifndef MCCONF_FOC_ENCODER_OFFSET
-    #define MCCONF_FOC_ENCODER_OFFSET    296.4
-#endif
-
 // Encoder Ratio
 #ifndef MCCONF_FOC_ENCODER_RATIO
     #define MCCONF_FOC_ENCODER_RATIO    4


### PR DESCRIPTION
closes #17 

This PR addresses the issue of losing motor encoder calibration values after a power cycle