### PR TITLE
Improve motor response at low speeds

### DIFF
--- a/hwconf/Zerno/mcconf_zerno_drive.h
+++ b/hwconf/Zerno/mcconf_zerno_drive.h
@@ -685,7 +685,7 @@
 
 // Speed PID Kp
 #ifndef MCCONF_S_PID_KP
-    #define MCCONF_S_PID_KP    0.013
+    #define MCCONF_S_PID_KP    0.008
 #endif
 
 // Speed PID Ki


### PR DESCRIPTION
closes #19 

At low speeds, the motor exhibited slight vibration, but not at high speeds. The proportional constant is configured to prevent sudden jumps that cause the motor to vibrate.