### PR TITLE
Change current limits and PID settings

### DIFF
--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -44,7 +44,7 @@
 #define CURRENT_MOTOR_TIMEOUT_MS                  (250)
 #define MOTOR_SELECTED                            (2)
 #define GRIND_TIMEOUT_SEC                         (600)
-#define CUTOFF_CURRENT_AMPS                       (4.2f)
+#define CUTOFF_CURRENT_AMPS                       (3.7f)
 #define NO_GRIND_CURRENT_AMPS                     (0.6f)
 #define GRIND_ATTEMPS                             (1)
 #define OFFSET_FACTOR_CORRECTION                  (0.05f)

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -78,7 +78,7 @@
 #define CALIBRATION_RATIO_VALUE                   (0.0f)
 #define CALIBRATION_OFFSET_VALUE                  (0.0f)
 #define SPEED_PID_KP_LOW                          (0.006)
-#define SPEED_PID_KP_HIGH                         (0.032)
+#define SPEED_PID_KP_HIGH                         (0.028)
 #define SPEED_PID_KD_HIGH                         (0.0001f)
 #define SPEED_PID_KD_LOW                          (0.00002f)
 #define SPEED_ERPM_RAMP_HIGH                      (10000.0f)

--- a/hwconf/Zerno/mcconf_zerno_drive.h
+++ b/hwconf/Zerno/mcconf_zerno_drive.h
@@ -690,7 +690,7 @@
 
 // Speed PID Kp
 #ifndef MCCONF_S_PID_KP
-#define MCCONF_S_PID_KP        0.032
+#define MCCONF_S_PID_KP        0.028
 #endif
 
 // Speed PID Ki


### PR DESCRIPTION
This PR refers to #50 

- Reduce cuttoff current threshold - A safety control to protect the motor before a high current event when it stalls.
- Reduce the Kp - This relaxes the PID speed controller.
- The current limits remain the same as previous versions unlike v1.1.0.

