### PR TITLE
Pid mode transition

### DIFF
--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -107,10 +107,10 @@
 #define PIN_13                                    (13)
 #define PIN_14                                    (14)
 #define PIN_15                                    (15)
-#define GRIND_CURRENT_DEFAULT_TH_AMPS             5.0f // this would be set to 2.5A
+#define GRIND_CURRENT_DEFAULT_TH_AMPS             1.0f // this would be set to 2.5A
 #define GRIND_CURRENT_HYSTERESIS_AMPS             0.3f
-#define GRIND_PID_DEFAULT_KP_MULTIPLIER           1.0f
-#define GRIND_PID_DEFAULT_KD_MULTIPLIER           1.0f
+#define GRIND_PID_DEFAULT_KP_MULTIPLIER           3.5f
+#define GRIND_PID_DEFAULT_KD_MULTIPLIER           20.0f
 #define GRIND_ENGAGE_DELAY_MS                     200
 #define GRIND_RELEASE_DELAY_MS                    400
 #define GRIND_PID_RAMP_STEPS                      30   // 30 × 10 ms loop = 300 ms transition
@@ -532,27 +532,31 @@ static void set_erpm_ramp_pid_response(void) {
 }
 
 static void enable_grind_pid(void) {
-	volatile const mc_configuration *conf = mc_interface_get_configuration();
+	volatile const mc_configuration* conf = mc_interface_get_configuration();
+
 	if (grind_original_kp < 0.0f) {
 		grind_original_kp = conf->s_pid_kp;
 		grind_original_kd = conf->s_pid_kd;
 	}
+
 	grind_ramp_is_restore = false;
 	start_grind_pid_ramp(grind_original_kp * grind_kp_multiplier,
-	                     grind_original_kd * grind_kd_multiplier);
+						 grind_original_kd * grind_kd_multiplier);
 }
 
 static void disable_grind_pid(void) {
-	if (grind_original_kp < 0.0f && grind_original_kd < 0.0f) {
+	if ((grind_original_kp < 0.0f) && (grind_original_kd < 0.0f)) {
 		grind_ramp_step = -1;
 		return;
 	}
+
 	grind_ramp_is_restore = true;
 	start_grind_pid_ramp(grind_original_kp, grind_original_kd);
 }
 
 static void start_grind_pid_ramp(float kp_to, float kd_to) {
-	volatile const mc_configuration *conf = mc_interface_get_configuration();
+	volatile const mc_configuration* conf = mc_interface_get_configuration();
+
 	grind_kp_ramp_from = conf->s_pid_kp;
 	grind_kd_ramp_from = conf->s_pid_kd;
 	grind_kp_ramp_to = kp_to;
@@ -572,7 +576,7 @@ static void grind_pid_ramp_step(void) {
 	float kp_next = grind_kp_ramp_from + (grind_kp_ramp_to - grind_kp_ramp_from) * t1;
 	float kd_next = grind_kd_ramp_from + (grind_kd_ramp_to - grind_kd_ramp_from) * t1;
 
-	mc_configuration *mcconf = mempools_alloc_mcconf();
+	mc_configuration* mcconf = mempools_alloc_mcconf();
 	*mcconf = *mc_interface_get_configuration();
 	mcconf->s_pid_kp = kp_next;
 	mcconf->s_pid_kd = kd_next;
@@ -581,6 +585,7 @@ static void grind_pid_ramp_step(void) {
 
 	if (done) {
 		grind_ramp_step = -1;
+
 		if (grind_ramp_is_restore) {
 			grind_original_kp = -1.0f;
 			grind_original_kd = -1.0f;
@@ -590,10 +595,12 @@ static void grind_pid_ramp_step(void) {
 
 static void reset_grind_pid_instant(void) {
 	grind_ramp_step = -1;
+
 	if (grind_original_kp < 0.0f) {
 		return;
 	}
-	mc_configuration *mcconf = mempools_alloc_mcconf();
+
+	mc_configuration* mcconf = mempools_alloc_mcconf();
 	*mcconf = *mc_interface_get_configuration();
 	mcconf->s_pid_kp = grind_original_kp;
 	mcconf->s_pid_kd = grind_original_kd;
@@ -700,7 +707,7 @@ static void terminal_set_grind_pid(int argc, const char** argv) {
 		float kp_mult = strtof(argv[2], NULL);
 		float kd_mult = strtof(argv[3], NULL);
 
-		if (th <= 0.0f || kp_mult <= 0.0f || kd_mult <= 0.0f) {
+		if ((th <= 0.0f) || (kp_mult <= 0.0f) || (kd_mult <= 0.0f)) {
 			commands_printf("Error: all values must be > 0");
 			return;
 		}
@@ -710,7 +717,7 @@ static void terminal_set_grind_pid(int argc, const char** argv) {
 		grind_kd_multiplier = kd_mult;
 
 		commands_printf("Grind PID set: threshold=%.2f A, kp_mult=%.3f, kd_mult=%.3f",
-			(double)grind_current_th_amps, (double)grind_kp_multiplier, (double)grind_kd_multiplier);
+						(double)grind_current_th_amps, (double)grind_kp_multiplier, (double)grind_kd_multiplier);
 	} else {
 		commands_printf("Usage: set_grind_pid <current_th_amps> <kp_multiplier> <kd_multiplier>");
 		commands_printf("Example: set_grind_pid 5.0 0.5 2.0");
@@ -780,7 +787,7 @@ static THD_FUNCTION(speed_thread, arg) {
 
 			if (switch_positions_in_volts > SWITCH_STOP_POSITION_IN_VOLTS) {
 				if (is_stop_state) {
-					if (grind_pid_active || grind_ramp_step >= 0) {
+					if (grind_pid_active || (grind_ramp_step >= 0)) {
 						reset_grind_pid_instant();
 						grind_pid_active = false;
 					}
@@ -859,7 +866,7 @@ static THD_FUNCTION(speed_thread, arg) {
 			}
 
 			if ((switch_positions_in_volts < SWITCH_MOMENTARY_POSITION_IN_VOLTS)) {
-				if (grind_pid_active || grind_ramp_step >= 0) {
+				if (grind_pid_active || (grind_ramp_step >= 0)) {
 					reset_grind_pid_instant();
 					grind_pid_active = false;
 				}
@@ -898,6 +905,7 @@ static THD_FUNCTION(speed_thread, arg) {
 
 			if ((mc_interface_get_tot_current() >= CUTOFF_CURRENT_AMPS)) {
 				overload_clear_time = SYSTICK_ZERO_VALUE;
+
 				if (overload_time_in_systicks == SYSTICK_ZERO_VALUE) {
 					overload_time_in_systicks = chVTGetSystemTime();
 				} else {

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -591,7 +591,7 @@ static void grind_pid_ramp_step(void) {
 	mcconf->s_pid_kd = kd_next;
 
 	// integrator is guaranteed zero. Restore Ki now.
-	if (grind_ramp_is_restore && (grind_original_ki >= 0.0f)) {
+	if (grind_ramp_is_restore && done && (grind_original_ki >= 0.0f)) {
 		mcconf->s_pid_ki = grind_original_ki;
 		grind_original_ki = -1.0f;
 	}

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -110,6 +110,9 @@
 #define GRIND_CURRENT_HYSTERESIS_AMPS             0.3f
 #define GRIND_PID_DEFAULT_KP_MULTIPLIER           1.0f
 #define GRIND_PID_DEFAULT_KD_MULTIPLIER           1.0f
+#define GRIND_ENGAGE_DELAY_MS                     200
+#define GRIND_RELEASE_DELAY_MS                    400
+#define GRIND_PID_RAMP_STEPS                      30   // 30 × 10 ms loop = 300 ms transition
 
 static THD_FUNCTION(speed_thread, arg);
 static THD_FUNCTION(encoder_thread, arg);
@@ -149,6 +152,12 @@ static float grind_kd_multiplier = GRIND_PID_DEFAULT_KD_MULTIPLIER;
 static float grind_original_kp = -1.0f;
 static float grind_original_kd = -1.0f;
 static bool grind_pid_active = false;
+static float grind_kp_ramp_from = 0.0f;
+static float grind_kp_ramp_to = 0.0f;
+static float grind_kd_ramp_from = 0.0f;
+static float grind_kd_ramp_to = 0.0f;
+static int grind_ramp_step = -1;
+static bool grind_ramp_is_restore = false;
 
 static uint8_t is_calibration_done = 0;
 static uint8_t head = 0;
@@ -170,6 +179,9 @@ static bool is_pfc_ok(void);
 static void terminal_print_info(int argc, const char** argv);
 static void enable_grind_pid(void);
 static void disable_grind_pid(void);
+static void reset_grind_pid_instant(void);
+static void start_grind_pid_ramp(float kp_to, float kd_to);
+static void grind_pid_ramp_step(void);
 static void terminal_set_grind_pid(int argc, const char** argv);
 static void terminal_get_grind_pid(int argc, const char** argv);
 
@@ -528,50 +540,75 @@ static void set_erpm_ramp_pid_response(void) {
 }
 
 static void enable_grind_pid(void) {
-	mc_configuration* mcconf = mempools_alloc_mcconf();
-	*mcconf = *mc_interface_get_configuration();
-	mc_configuration* mcconf_previous = mempools_alloc_mcconf();
-	*mcconf_previous = *mcconf;
-
-	grind_original_kp = mcconf->s_pid_kp;
-	grind_original_kd = mcconf->s_pid_kd;
-
-	mcconf->s_pid_kp = grind_original_kp * grind_kp_multiplier;
-	mcconf->s_pid_kd = grind_original_kd * grind_kd_multiplier;
-
-	mc_interface_set_configuration(mcconf_previous);
-	mc_interface_set_configuration(mcconf);
-
-	mempools_free_mcconf(mcconf);
-	mempools_free_mcconf(mcconf_previous);
+	const mc_configuration *conf = mc_interface_get_configuration();
+	if (grind_original_kp < 0.0f) {
+		grind_original_kp = conf->s_pid_kp;
+		grind_original_kd = conf->s_pid_kd;
+	}
+	grind_ramp_is_restore = false;
+	start_grind_pid_ramp(grind_original_kp * grind_kp_multiplier,
+	                     grind_original_kd * grind_kd_multiplier);
 }
 
 static void disable_grind_pid(void) {
 	if (grind_original_kp < 0.0f && grind_original_kd < 0.0f) {
+		grind_ramp_step = -1;
+		return;
+	}
+	grind_ramp_is_restore = true;
+	start_grind_pid_ramp(grind_original_kp, grind_original_kd);
+}
+
+static void start_grind_pid_ramp(float kp_to, float kd_to) {
+	const mc_configuration *conf = mc_interface_get_configuration();
+	grind_kp_ramp_from = conf->s_pid_kp;
+	grind_kd_ramp_from = conf->s_pid_kd;
+	grind_kp_ramp_to = kp_to;
+	grind_kd_ramp_to = kd_to;
+	grind_ramp_step = 0;
+}
+
+static void grind_pid_ramp_step(void) {
+	if (grind_ramp_step < 0) {
 		return;
 	}
 
-	mc_configuration* mcconf = mempools_alloc_mcconf();
+	grind_ramp_step++;
+	bool done = (grind_ramp_step >= GRIND_PID_RAMP_STEPS);
+	float t1 = done ? 1.0f : ((float)grind_ramp_step / (float)GRIND_PID_RAMP_STEPS);
+
+	float kp_next = grind_kp_ramp_from + (grind_kp_ramp_to - grind_kp_ramp_from) * t1;
+	float kd_next = grind_kd_ramp_from + (grind_kd_ramp_to - grind_kd_ramp_from) * t1;
+
+	mc_configuration *mcconf = mempools_alloc_mcconf();
 	*mcconf = *mc_interface_get_configuration();
-	mc_configuration* mcconf_previous = mempools_alloc_mcconf();
-	*mcconf_previous = *mcconf;
+	mcconf->s_pid_kp = kp_next;
+	mcconf->s_pid_kd = kd_next;
+	mc_interface_set_configuration(mcconf);
+	mempools_free_mcconf(mcconf);
 
-	if (grind_original_kp >= 0.0f) {
-		mcconf->s_pid_kp = grind_original_kp;
+	if (done) {
+		grind_ramp_step = -1;
+		if (grind_ramp_is_restore) {
+			grind_original_kp = -1.0f;
+			grind_original_kd = -1.0f;
+		}
 	}
+}
 
-	if (grind_original_kd >= 0.0f) {
-		mcconf->s_pid_kd = grind_original_kd;
+static void reset_grind_pid_instant(void) {
+	grind_ramp_step = -1;
+	if (grind_original_kp < 0.0f) {
+		return;
 	}
-
+	mc_configuration *mcconf = mempools_alloc_mcconf();
+	*mcconf = *mc_interface_get_configuration();
+	mcconf->s_pid_kp = grind_original_kp;
+	mcconf->s_pid_kd = grind_original_kd;
+	mc_interface_set_configuration(mcconf);
+	mempools_free_mcconf(mcconf);
 	grind_original_kp = -1.0f;
 	grind_original_kd = -1.0f;
-
-	mc_interface_set_configuration(mcconf_previous);
-	mc_interface_set_configuration(mcconf);
-
-	mempools_free_mcconf(mcconf);
-	mempools_free_mcconf(mcconf_previous);
 }
 
 static void motor_encoder_calibrate_offset(void) {
@@ -738,6 +775,8 @@ static THD_FUNCTION(speed_thread, arg) {
 
 	static systime_t overload_time_in_systicks = SYSTICK_ZERO_VALUE;
 	static systime_t no_grind_time_in_systicks = SYSTICK_ZERO_VALUE;
+	static systime_t grind_engage_time = SYSTICK_ZERO_VALUE;
+	static systime_t grind_release_time = SYSTICK_ZERO_VALUE;
 
 	for (;;) {
 		// TODO: Add a safety condition, just to avoid undesired behavior when main switch is disconnected.
@@ -748,11 +787,13 @@ static THD_FUNCTION(speed_thread, arg) {
 
 			if (switch_positions_in_volts > SWITCH_STOP_POSITION_IN_VOLTS) {
 				if (is_stop_state) {
-					if (grind_pid_active) {
-						disable_grind_pid();
+					if (grind_pid_active || grind_ramp_step >= 0) {
+						reset_grind_pid_instant();
 						grind_pid_active = false;
 					}
 
+					grind_engage_time = SYSTICK_ZERO_VALUE;
+					grind_release_time = SYSTICK_ZERO_VALUE;
 					mc_interface_release_motor();
 					is_stop_state = false;
 					is_momentary_position_status = false;
@@ -778,14 +819,33 @@ static THD_FUNCTION(speed_thread, arg) {
 				float current_actual = mc_interface_get_tot_current_filtered();
 
 				// Grinding current PID adaptation: adjust Kp/Kd when motor hits high load
-				if (!grind_pid_active && current_actual >= grind_current_th_amps) {
-					enable_grind_pid();
-					grind_pid_active = true;
-				} else if (grind_pid_active && current_actual < (grind_current_th_amps - GRIND_CURRENT_HYSTERESIS_AMPS)) {
-					disable_grind_pid();
-					grind_pid_active = false;
+				if (!grind_pid_active) {
+					if (current_actual >= grind_current_th_amps) {
+						if (grind_engage_time == SYSTICK_ZERO_VALUE) {
+							grind_engage_time = chVTGetSystemTime();
+						} else if (chVTTimeElapsedSinceX(grind_engage_time) > MS2ST(GRIND_ENGAGE_DELAY_MS)) {
+							enable_grind_pid();
+							grind_pid_active = true;
+							grind_engage_time = SYSTICK_ZERO_VALUE;
+						}
+					} else {
+						grind_engage_time = SYSTICK_ZERO_VALUE;
+					}
+				} else {
+					if (current_actual < (grind_current_th_amps - GRIND_CURRENT_HYSTERESIS_AMPS)) {
+						if (grind_release_time == SYSTICK_ZERO_VALUE) {
+							grind_release_time = chVTGetSystemTime();
+						} else if (chVTTimeElapsedSinceX(grind_release_time) > MS2ST(GRIND_RELEASE_DELAY_MS)) {
+							disable_grind_pid();
+							grind_pid_active = false;
+							grind_release_time = SYSTICK_ZERO_VALUE;
+						}
+					} else {
+						grind_release_time = SYSTICK_ZERO_VALUE;
+					}
 				}
 
+				grind_pid_ramp_step();
 				mc_interface_set_pid_speed(speed_erpm_setpoint);
 
 				if (mc_interface_get_tot_current() < NO_GRIND_CURRENT_AMPS) {
@@ -806,10 +866,13 @@ static THD_FUNCTION(speed_thread, arg) {
 			}
 
 			if ((switch_positions_in_volts < SWITCH_MOMENTARY_POSITION_IN_VOLTS)) {
-				if (grind_pid_active) {
-					disable_grind_pid();
+				if (grind_pid_active || grind_ramp_step >= 0) {
+					reset_grind_pid_instant();
 					grind_pid_active = false;
 				}
+
+				grind_engage_time = SYSTICK_ZERO_VALUE;
+				grind_release_time = SYSTICK_ZERO_VALUE;
 
 				if (safety_calibration) {
 					change_erpm_ramp_pid_mom_state = true;

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -152,6 +152,7 @@ static float grind_kp_multiplier = GRIND_PID_DEFAULT_KP_MULTIPLIER;
 static float grind_kd_multiplier = GRIND_PID_DEFAULT_KD_MULTIPLIER;
 static float grind_original_kp = -1.0f;
 static float grind_original_kd = -1.0f;
+static float grind_original_ki = -1.0f;
 static bool grind_pid_active = false;
 static float grind_kp_ramp_from = 0.0f;
 static float grind_kp_ramp_to = 0.0f;
@@ -550,6 +551,14 @@ static void disable_grind_pid(void) {
 		return;
 	}
 
+	// draining the integrator windup accumulated during grinding before the ramp starts.
+	mc_configuration* mcconf = mempools_alloc_mcconf();
+	*mcconf = *mc_interface_get_configuration();
+	grind_original_ki = mcconf->s_pid_ki;
+	mcconf->s_pid_ki = 0.0f; // a quick way to avoid erpm wind-up.
+	mc_interface_set_configuration(mcconf);
+	mempools_free_mcconf(mcconf);
+
 	grind_ramp_is_restore = true;
 	start_grind_pid_ramp(grind_original_kp, grind_original_kd);
 }
@@ -580,6 +589,13 @@ static void grind_pid_ramp_step(void) {
 	*mcconf = *mc_interface_get_configuration();
 	mcconf->s_pid_kp = kp_next;
 	mcconf->s_pid_kd = kd_next;
+
+	// integrator is guaranteed zero. Restore Ki now.
+	if (grind_ramp_is_restore && (grind_original_ki >= 0.0f)) {
+		mcconf->s_pid_ki = grind_original_ki;
+		grind_original_ki = -1.0f;
+	}
+
 	mc_interface_set_configuration(mcconf);
 	mempools_free_mcconf(mcconf);
 
@@ -597,6 +613,7 @@ static void reset_grind_pid_instant(void) {
 	grind_ramp_step = -1;
 
 	if (grind_original_kp < 0.0f) {
+		grind_original_ki = -1.0f;
 		return;
 	}
 
@@ -604,6 +621,12 @@ static void reset_grind_pid_instant(void) {
 	*mcconf = *mc_interface_get_configuration();
 	mcconf->s_pid_kp = grind_original_kp;
 	mcconf->s_pid_kd = grind_original_kd;
+
+	if (grind_original_ki >= 0.0f) {
+		mcconf->s_pid_ki = grind_original_ki;
+		grind_original_ki = -1.0f;
+	}
+
 	mc_interface_set_configuration(mcconf);
 	mempools_free_mcconf(mcconf);
 	grind_original_kp = -1.0f;

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -46,7 +46,6 @@
 #define GRIND_TIMEOUT_SEC                         (600)
 #define CUTOFF_CURRENT_AMPS                       (4.0f)
 #define NO_GRIND_CURRENT_AMPS                     (0.6f)
-#define GRIND_ATTEMPS                             (1)
 #define OFFSET_FACTOR_CORRECTION                  (0.05f)
 #define SPEED_MIN_ERPM                            (800.0f)
 #define SPEED_ERPM_STEP                           (200.0f)
@@ -77,12 +76,11 @@
 #define CALIBRATION_CURRENT                       (2.0f)
 #define CALIBRATION_RATIO_VALUE                   (0.0f)
 #define CALIBRATION_OFFSET_VALUE                  (0.0f)
-#define SPEED_PID_KP_LOW                          (0.012f)
-#define SPEED_PID_KP_HIGH                         (0.012f)
+#define SPEED_PID_KP_LOW                          (0.008f)
+#define SPEED_PID_KP_HIGH                         (0.008f)
 #define SPEED_ERPM_RAMP_HIGH                      (10000.0f)
 #define SPEED_ERPM_RAMP_LOW                       (5000.0f)
 #define SYSTICK_ZERO_VALUE                        (0.0f)
-#define ZERO_GRIND_ATTEMPS                        (0)
 #define SPEED_THREAD_STACK_SIZE                   (1024)
 #define ENCODER_THREAD_STACK_SIZE                 (1024)
 #define SAMPLES                                   (15)
@@ -108,13 +106,10 @@
 #define PIN_13                                    (13)
 #define PIN_14                                    (14)
 #define PIN_15                                    (15)
-#define STALL_RPM_ERROR_TH                        300.0f
-#define STALL_CURRENT_TH_AMPS                     3.7f
-#define STALL_BOOST_AMPS                          10.0f
-#define STALL_KP_MULTIPLIER                       2.33f
-#define STALL_KD_MULTIPLIER                       20.0f
-#define STALL_BOOST_MS                            200
-#define STALL_COOLDOWN_MS                         500
+#define GRIND_CURRENT_DEFAULT_TH_AMPS             5.0f // this would be set to 2.5A
+#define GRIND_CURRENT_HYSTERESIS_AMPS             0.3f
+#define GRIND_PID_DEFAULT_KP_MULTIPLIER           1.0f
+#define GRIND_PID_DEFAULT_KD_MULTIPLIER           1.0f
 
 static THD_FUNCTION(speed_thread, arg);
 static THD_FUNCTION(encoder_thread, arg);
@@ -143,15 +138,17 @@ static volatile bool is_encoder_done = false;
 static volatile bool i2c_running = false;
 
 static bool is_stop_state = false;
-static bool is_motor_stalled_fault = false;
 static bool is_motor_grinding_enable = true;
 static bool is_in_maximum_detection = false;
 static bool change_erpm_ramp_pid_on_state = false;
 static bool change_erpm_ramp_pid_mom_state = false;
-static float original_current_max = -1.0f;
-static float original_kp = -1.0f;
-static float original_kd = -1.0f;
-static uint32_t stall_event_count = 0;
+
+static float grind_current_th_amps = GRIND_CURRENT_DEFAULT_TH_AMPS;
+static float grind_kp_multiplier = GRIND_PID_DEFAULT_KP_MULTIPLIER;
+static float grind_kd_multiplier = GRIND_PID_DEFAULT_KD_MULTIPLIER;
+static float grind_original_kp = -1.0f;
+static float grind_original_kd = -1.0f;
+static bool grind_pid_active = false;
 
 static uint8_t is_calibration_done = 0;
 static uint8_t head = 0;
@@ -171,7 +168,10 @@ static float main_switch_adc_value(void);
 static bool is_pfc_ok(void);
 
 static void terminal_print_info(int argc, const char** argv);
-static void terminal_stall_events(int argc, const char** argv);
+static void enable_grind_pid(void);
+static void disable_grind_pid(void);
+static void terminal_set_grind_pid(int argc, const char** argv);
+static void terminal_get_grind_pid(int argc, const char** argv);
 
 static const float erpm_lut[14] = {
 	1000.0,
@@ -290,10 +290,16 @@ void hw_init_gpio(void) {
 		terminal_print_info);
 
 	terminal_register_command_callback(
-		"stall_events",
-		"Print the number of times the stall prevention boost has fired",
+		"set_grind_pid",
+		"Set grinding PID params: set_grind_pid <current_th_amps> <kp_multiplier> <kd_multiplier>",
+		"[current_th] [kp_mult] [kd_mult]",
+		terminal_set_grind_pid);
+
+	terminal_register_command_callback(
+		"get_grind_pid",
+		"Print current grinding PID parameters and state",
 		0,
-		terminal_stall_events);
+		terminal_get_grind_pid);
 }
 
 void hw_setup_adc_channels(void) {
@@ -521,33 +527,17 @@ static void set_erpm_ramp_pid_response(void) {
 	is_erpm_done = true;
 }
 
-static void enable_stall_boost(void) {
+static void enable_grind_pid(void) {
 	mc_configuration* mcconf = mempools_alloc_mcconf();
-
 	*mcconf = *mc_interface_get_configuration();
 	mc_configuration* mcconf_previous = mempools_alloc_mcconf();
 	*mcconf_previous = *mcconf;
 
-	if (original_current_max < 0.0f) {
-		original_current_max = mcconf->l_current_max;
-	}
+	grind_original_kp = mcconf->s_pid_kp;
+	grind_original_kd = mcconf->s_pid_kd;
 
-	if (original_kp < 0.0f) {
-		original_kp = mcconf->s_pid_kp;
-	}
-
-	if (original_kd < 0.0f) {
-		original_kd = mcconf->s_pid_kd;
-	}
-
-	if (STALL_BOOST_AMPS > original_current_max) {
-		mcconf->l_current_max = STALL_BOOST_AMPS;
-	}
-
-	mcconf->s_pid_kp = original_kp * STALL_KP_MULTIPLIER;
-	mcconf->s_pid_kd = original_kd * STALL_KD_MULTIPLIER;
-
-	stall_event_count++;
+	mcconf->s_pid_kp = grind_original_kp * grind_kp_multiplier;
+	mcconf->s_pid_kd = grind_original_kd * grind_kd_multiplier;
 
 	mc_interface_set_configuration(mcconf_previous);
 	mc_interface_set_configuration(mcconf);
@@ -556,8 +546,8 @@ static void enable_stall_boost(void) {
 	mempools_free_mcconf(mcconf_previous);
 }
 
-static void disable_stall_boost(void) {
-	if ((original_current_max < 0.0f) && (original_kp < 0.0f) && (original_kd < 0.0f)) {
+static void disable_grind_pid(void) {
+	if (grind_original_kp < 0.0f && grind_original_kd < 0.0f) {
 		return;
 	}
 
@@ -566,17 +556,16 @@ static void disable_stall_boost(void) {
 	mc_configuration* mcconf_previous = mempools_alloc_mcconf();
 	*mcconf_previous = *mcconf;
 
-	if (original_current_max >= 0.0f) {
-		mcconf->l_current_max = original_current_max;
+	if (grind_original_kp >= 0.0f) {
+		mcconf->s_pid_kp = grind_original_kp;
 	}
 
-	if (original_kp >= 0.0f) {
-		mcconf->s_pid_kp = original_kp;
+	if (grind_original_kd >= 0.0f) {
+		mcconf->s_pid_kd = grind_original_kd;
 	}
 
-	if (original_kd >= 0.0f) {
-		mcconf->s_pid_kd = original_kd;
-	}
+	grind_original_kp = -1.0f;
+	grind_original_kd = -1.0f;
 
 	mc_interface_set_configuration(mcconf_previous);
 	mc_interface_set_configuration(mcconf);
@@ -584,6 +573,7 @@ static void disable_stall_boost(void) {
 	mempools_free_mcconf(mcconf);
 	mempools_free_mcconf(mcconf_previous);
 }
+
 static void motor_encoder_calibrate_offset(void) {
 	mc_configuration* mcconf = mempools_alloc_mcconf();
 
@@ -675,11 +665,37 @@ float get_pfc_temp(void) {
 	return temp_pfc_filtered;
 }
 
-static void terminal_stall_events(int argc, const char** argv) {
+static void terminal_set_grind_pid(int argc, const char** argv) {
+	if (argc == 4) {
+		float th = strtof(argv[1], NULL);
+		float kp_mult = strtof(argv[2], NULL);
+		float kd_mult = strtof(argv[3], NULL);
+
+		if (th <= 0.0f || kp_mult <= 0.0f || kd_mult <= 0.0f) {
+			commands_printf("Error: all values must be > 0");
+			return;
+		}
+
+		grind_current_th_amps = th;
+		grind_kp_multiplier = kp_mult;
+		grind_kd_multiplier = kd_mult;
+
+		commands_printf("Grind PID set: threshold=%.2f A, kp_mult=%.3f, kd_mult=%.3f",
+			(double)grind_current_th_amps, (double)grind_kp_multiplier, (double)grind_kd_multiplier);
+	} else {
+		commands_printf("Usage: set_grind_pid <current_th_amps> <kp_multiplier> <kd_multiplier>");
+		commands_printf("Example: set_grind_pid 5.0 0.5 2.0");
+	}
+}
+
+static void terminal_get_grind_pid(int argc, const char** argv) {
 	(void)argc;
 	(void)argv;
 
-	commands_printf("Stall boost events: %u", stall_event_count);
+	commands_printf("Grind PID threshold: %.2f A", (double)grind_current_th_amps);
+	commands_printf("Grind PID Kp multiplier: %.3f", (double)grind_kp_multiplier);
+	commands_printf("Grind PID Kd multiplier: %.3f", (double)grind_kd_multiplier);
+	commands_printf("Grind PID active: %s", grind_pid_active ? "YES" : "NO");
 }
 
 static void terminal_print_info(int argc, const char** argv) {
@@ -722,12 +738,6 @@ static THD_FUNCTION(speed_thread, arg) {
 
 	static systime_t overload_time_in_systicks = SYSTICK_ZERO_VALUE;
 	static systime_t no_grind_time_in_systicks = SYSTICK_ZERO_VALUE;
-	static systime_t stall_boost_start_time = 0;
-	static systime_t stall_boost_cooldown_time = 0;
-
-	static uint8_t grind_attemp = ZERO_GRIND_ATTEMPS;
-
-	static bool stall_boost_active = false;
 
 	for (;;) {
 		// TODO: Add a safety condition, just to avoid undesired behavior when main switch is disconnected.
@@ -738,18 +748,14 @@ static THD_FUNCTION(speed_thread, arg) {
 
 			if (switch_positions_in_volts > SWITCH_STOP_POSITION_IN_VOLTS) {
 				if (is_stop_state) {
-					if (stall_boost_active) {
-						disable_stall_boost();
-						stall_boost_active = false;
+					if (grind_pid_active) {
+						disable_grind_pid();
+						grind_pid_active = false;
 					}
 
-					original_current_max = -1.0f;
-					original_kp = -1.0f;
-					original_kd = -1.0f;
 					mc_interface_release_motor();
 					is_stop_state = false;
 					is_momentary_position_status = false;
-					is_motor_stalled_fault = false;
 					is_motor_grinding_enable = true;
 					no_grind_time_in_systicks = SYSTICK_ZERO_VALUE;
 				}
@@ -759,7 +765,7 @@ static THD_FUNCTION(speed_thread, arg) {
 				is_encoder_done = false;
 			}
 
-			if ((switch_positions_in_volts > SWITCH_ON_POSITION_1_IN_VOLTS) && (switch_positions_in_volts < SWITCH_ON_POSITION_2_IN_VOLTS) && is_calibration_done && !is_motor_stalled_fault && is_motor_grinding_enable) {
+			if ((switch_positions_in_volts > SWITCH_ON_POSITION_1_IN_VOLTS) && (switch_positions_in_volts < SWITCH_ON_POSITION_2_IN_VOLTS) && is_calibration_done && is_motor_grinding_enable) {
 				change_erpm_ramp_pid_mom_state = false;
 				change_erpm_ramp_pid_on_state = true;
 
@@ -769,24 +775,15 @@ static THD_FUNCTION(speed_thread, arg) {
 
 				timeout_reset();
 
-				float rpm_actual = mc_interface_get_rpm();
-				float rpm_error = speed_erpm_setpoint - rpm_actual;
 				float current_actual = mc_interface_get_tot_current_filtered();
-				systime_t now = chVTGetSystemTimeX();
 
-				bool cooldown_ok = (chVTTimeElapsedSinceX(stall_boost_cooldown_time) > MS2ST(STALL_COOLDOWN_MS));
-
-				if (stall_boost_active) {
-					if (chVTTimeElapsedSinceX(stall_boost_start_time) > MS2ST(STALL_BOOST_MS)) {
-						disable_stall_boost();
-						stall_boost_active = false;
-						stall_boost_cooldown_time = now;
-					}
-				} else if (cooldown_ok && (rpm_error > STALL_RPM_ERROR_TH) && (current_actual > STALL_CURRENT_TH_AMPS)) {
-					enable_stall_boost();
-					stall_boost_active = true;
-					stall_boost_start_time = now;
-					overload_time_in_systicks = SYSTICK_ZERO_VALUE;
+				// Grinding current PID adaptation: adjust Kp/Kd when motor hits high load
+				if (!grind_pid_active && current_actual >= grind_current_th_amps) {
+					enable_grind_pid();
+					grind_pid_active = true;
+				} else if (grind_pid_active && current_actual < (grind_current_th_amps - GRIND_CURRENT_HYSTERESIS_AMPS)) {
+					disable_grind_pid();
+					grind_pid_active = false;
 				}
 
 				mc_interface_set_pid_speed(speed_erpm_setpoint);
@@ -809,10 +806,9 @@ static THD_FUNCTION(speed_thread, arg) {
 			}
 
 			if ((switch_positions_in_volts < SWITCH_MOMENTARY_POSITION_IN_VOLTS)) {
-				if (stall_boost_active) {
-					disable_stall_boost();
-					stall_boost_active = false;
-					overload_time_in_systicks = SYSTICK_ZERO_VALUE;
+				if (grind_pid_active) {
+					disable_grind_pid();
+					grind_pid_active = false;
 				}
 
 				if (safety_calibration) {
@@ -845,21 +841,12 @@ static THD_FUNCTION(speed_thread, arg) {
 			}
 
 			if ((mc_interface_get_tot_current() >= CUTOFF_CURRENT_AMPS)) {
-				if (!stall_boost_active) {
-					if (overload_time_in_systicks == SYSTICK_ZERO_VALUE) {
-						overload_time_in_systicks = chVTGetSystemTime();
-					} else {
-						if (chVTTimeElapsedSinceX(overload_time_in_systicks) > MS2ST(CURRENT_MOTOR_TIMEOUT_MS)) {
-							mc_interface_release_motor();
-							grind_attemp++;
-
-							if (grind_attemp == GRIND_ATTEMPS) {
-								is_motor_stalled_fault = true;
-								grind_attemp = ZERO_GRIND_ATTEMPS;
-							}
-
-							overload_time_in_systicks = SYSTICK_ZERO_VALUE;
-						}
+				if (overload_time_in_systicks == SYSTICK_ZERO_VALUE) {
+					overload_time_in_systicks = chVTGetSystemTime();
+				} else {
+					if (chVTTimeElapsedSinceX(overload_time_in_systicks) > MS2ST(CURRENT_MOTOR_TIMEOUT_MS)) {
+						mc_interface_release_motor();
+						overload_time_in_systicks = SYSTICK_ZERO_VALUE;
 					}
 				}
 			} else {

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -173,7 +173,7 @@ static void knob_encoder_calibrate_offset(void);
 static void adc_get_maximum_value(void);
 static void write_adc_value_in_volts(void);
 static void read_adc_value_in_volts(void);
-static float main_switch_adc_value(void);
+
 
 static bool is_pfc_ok(void);
 
@@ -458,15 +458,6 @@ static bool is_pfc_ok(void) {
 
 /* Enable adc readings for main switch */
 
-static float main_switch_adc_value(void) {
-	static float main_switch;
-	static float main_switch_filtered;
-
-	main_switch = ADC_VOLTS(ADC_IND_EXT2);
-	UTILS_LP_FAST(main_switch_filtered, main_switch, SWITCH_FILTER_CONSTANT);
-
-	return main_switch_filtered;
-}
 
 /* Load the stored values during start-up
  *
@@ -541,7 +532,7 @@ static void set_erpm_ramp_pid_response(void) {
 }
 
 static void enable_grind_pid(void) {
-	const mc_configuration *conf = mc_interface_get_configuration();
+	volatile const mc_configuration *conf = mc_interface_get_configuration();
 	if (grind_original_kp < 0.0f) {
 		grind_original_kp = conf->s_pid_kp;
 		grind_original_kd = conf->s_pid_kd;
@@ -561,7 +552,7 @@ static void disable_grind_pid(void) {
 }
 
 static void start_grind_pid_ramp(float kp_to, float kd_to) {
-	const mc_configuration *conf = mc_interface_get_configuration();
+	volatile const mc_configuration *conf = mc_interface_get_configuration();
 	grind_kp_ramp_from = conf->s_pid_kp;
 	grind_kd_ramp_from = conf->s_pid_kd;
 	grind_kp_ramp_to = kp_to;

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -42,6 +42,7 @@
 #define EEPROM_ADDR_STEPS_VALUE                   (10)
 #define EEPROM_ADDR_ADC_MAX_VALUE                 (12)
 #define CURRENT_MOTOR_TIMEOUT_MS                  (250)
+#define OVERLOAD_CLEAR_DELAY_MS                   (250)
 #define MOTOR_SELECTED                            (2)
 #define GRIND_TIMEOUT_SEC                         (600)
 #define CUTOFF_CURRENT_AMPS                       (4.0f)
@@ -774,6 +775,7 @@ static THD_FUNCTION(speed_thread, arg) {
 	chThdSleepMilliseconds(2000);
 
 	static systime_t overload_time_in_systicks = SYSTICK_ZERO_VALUE;
+	static systime_t overload_clear_time = SYSTICK_ZERO_VALUE;
 	static systime_t no_grind_time_in_systicks = SYSTICK_ZERO_VALUE;
 	static systime_t grind_engage_time = SYSTICK_ZERO_VALUE;
 	static systime_t grind_release_time = SYSTICK_ZERO_VALUE;
@@ -904,16 +906,27 @@ static THD_FUNCTION(speed_thread, arg) {
 			}
 
 			if ((mc_interface_get_tot_current() >= CUTOFF_CURRENT_AMPS)) {
+				overload_clear_time = SYSTICK_ZERO_VALUE;
 				if (overload_time_in_systicks == SYSTICK_ZERO_VALUE) {
 					overload_time_in_systicks = chVTGetSystemTime();
 				} else {
 					if (chVTTimeElapsedSinceX(overload_time_in_systicks) > MS2ST(CURRENT_MOTOR_TIMEOUT_MS)) {
 						mc_interface_release_motor();
+						is_motor_grinding_enable = false;
 						overload_time_in_systicks = SYSTICK_ZERO_VALUE;
 					}
 				}
 			} else {
-				overload_time_in_systicks = SYSTICK_ZERO_VALUE;
+				if (overload_time_in_systicks != SYSTICK_ZERO_VALUE) {
+					if (overload_clear_time == SYSTICK_ZERO_VALUE) {
+						overload_clear_time = chVTGetSystemTime();
+					} else if (chVTTimeElapsedSinceX(overload_clear_time) > MS2ST(OVERLOAD_CLEAR_DELAY_MS)) {
+						overload_time_in_systicks = SYSTICK_ZERO_VALUE;
+						overload_clear_time = SYSTICK_ZERO_VALUE;
+					}
+				} else {
+					overload_clear_time = SYSTICK_ZERO_VALUE;
+				}
 			}
 		}
 

--- a/hwconf/Zerno/hw_zerno_drive_core.c
+++ b/hwconf/Zerno/hw_zerno_drive_core.c
@@ -112,7 +112,7 @@
 #define GRIND_PID_DEFAULT_KP_MULTIPLIER           3.5f
 #define GRIND_PID_DEFAULT_KD_MULTIPLIER           20.0f
 #define GRIND_ENGAGE_DELAY_MS                     200
-#define GRIND_RELEASE_DELAY_MS                    400
+#define GRIND_RELEASE_DELAY_MS                    200
 #define GRIND_PID_RAMP_STEPS                      30   // 30 × 10 ms loop = 300 ms transition
 
 static THD_FUNCTION(speed_thread, arg);

--- a/hwconf/Zerno/mcconf_zerno_drive.h
+++ b/hwconf/Zerno/mcconf_zerno_drive.h
@@ -690,7 +690,7 @@
 
 // Speed PID Kp
 #ifndef MCCONF_S_PID_KP
-#define MCCONF_S_PID_KP        0.012
+#define MCCONF_S_PID_KP        0.008
 #endif
 
 // Speed PID Ki


### PR DESCRIPTION
PR referring to #54 

Add a PID mode transition method: This changes the Kp and Kd settings when grinding. It softens the PID when no grinding is being done and makes it stronger when grinding.